### PR TITLE
Avoid reading the MDC theme on every composition

### DIFF
--- a/mdc-theme/src/main/java/dev/chrisbanes/accompanist/mdctheme/MaterialThemeFromMdcTheme.kt
+++ b/mdc-theme/src/main/java/dev/chrisbanes/accompanist/mdctheme/MaterialThemeFromMdcTheme.kt
@@ -566,13 +566,15 @@ private inline val TypedValue.complexUnitCompat
  * The cost of this reflective invoke is a lot cheaper than the full theme read which currently
  * happens on every re-composition.
  */
+@get:Suppress("PrivateApi")
 private inline val Resources.Theme.key: Any?
     get() = try {
         sThemeGetKeyMethod.invoke(this)
     } catch (e: ReflectiveOperationException) {
-        Log.i("MaterialThemeFromMdcTheme", "Failed to retrieve theme key", e)
+        Log.i("MaterialThemeFromMdc", "Failed to retrieve theme key", e)
     }
 
+@delegate:Suppress("PrivateApi")
 private val sThemeGetKeyMethod: Method by lazy {
     Resources.Theme::class.java.getDeclaredMethod("getKey").apply {
         isAccessible = true


### PR DESCRIPTION
Currently the theme is read on every recomposition, which is obviously very wasteful. Reading from a theme is very slow so we should cache the values when the theme hasn't actually changed.

`Theme` does not currently implement normal object equality, so we need to use the internal and hidden `getKey()` method to use as an equality key.

/cc @alanv