### PR TITLE
Use picsum.images for sample app

### DIFF
--- a/sample/src/main/java/dev/chrisbanes/accompanist/sample/coil/CoilSampleActivity.kt
+++ b/sample/src/main/java/dev/chrisbanes/accompanist/sample/coil/CoilSampleActivity.kt
@@ -75,14 +75,14 @@ fun CoilSample() {
             ) {
                 // CoilImage with data parameter
                 CoilImage(
-                    data = "https://loremflickr.com/300/300",
+                    data = sampleImageUrl,
                     modifier = Modifier.preferredSize(128.dp, 128.dp)
                 )
 
                 // CoilImage with GetRequest parameter
                 CoilImage(
                     request = GetRequest.Builder(ContextAmbient.current)
-                        .data("https://loremflickr.com/300/300")
+                        .data(sampleImageUrl)
                         .transformations(CircleCropTransformation())
                         .build(),
                     modifier = Modifier.preferredSize(128.dp, 128.dp)
@@ -90,7 +90,7 @@ fun CoilSample() {
 
                 // CoilImage with loading slot
                 CoilImage(
-                    data = "https://loremflickr.com/300/300",
+                    data = sampleImageUrl,
                     loading = {
                         Stack(Modifier.fillMaxSize()) {
                             CircularProgressIndicator(Modifier.gravity(Alignment.Center))
@@ -101,14 +101,14 @@ fun CoilSample() {
 
                 // CoilImageWithCrossfade with data parameter
                 CoilImageWithCrossfade(
-                    data = "https://loremflickr.com/300/300",
+                    data = sampleImageUrl,
                     modifier = Modifier.preferredSize(128.dp, 128.dp)
                 )
 
                 // CoilImageWithCrossfade with GetRequest parameter
                 CoilImageWithCrossfade(
                     request = GetRequest.Builder(ContextAmbient.current)
-                        .data("https://loremflickr.com/300/300")
+                        .data(sampleImageUrl)
                         .transformations(CircleCropTransformation())
                         .build(),
                     modifier = Modifier.preferredSize(128.dp, 128.dp)
@@ -116,7 +116,7 @@ fun CoilSample() {
 
                 // CoilImageWithCrossfade with loading slot
                 CoilImageWithCrossfade(
-                    data = "https://loremflickr.com/300/300",
+                    data = sampleImageUrl,
                     loading = {
                         Stack(Modifier.fillMaxSize()) {
                             CircularProgressIndicator(Modifier.gravity(Alignment.Center))
@@ -128,3 +128,5 @@ fun CoilSample() {
         }
     }
 }
+
+private const val sampleImageUrl = "https://picsum.photos/300/300"


### PR DESCRIPTION
Some of the images on `loremflickr.com` were not appropriate for a public sample. `picsum.images` contains a curated list of images which are appropriate.