### PR TITLE
Improve MDC theme assertion

### DIFF
--- a/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
@@ -21,7 +21,7 @@ object Versions {
 }
 
 object Libs {
-    const val androidGradlePlugin = "com.android.tools.build:gradle:4.2.0-alpha01"
+    const val androidGradlePlugin = "com.android.tools.build:gradle:4.2.0-alpha02"
 
     const val gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.11.1"
 

--- a/mdc-theme/src/androidTest/AndroidManifest.xml
+++ b/mdc-theme/src/androidTest/AndroidManifest.xml
@@ -25,6 +25,10 @@
             android:name=".MdcActivity"
             android:theme="@style/Theme.MdcThemeTest" />
 
+        <activity
+            android:name=".NotMdcActivity"
+            android:theme="@style/Theme.MdcThemeTest.NotMdc" />
+
     </application>
 
 </manifest>

--- a/mdc-theme/src/androidTest/java/dev/chrisbanes/accompanist/mdctheme/MaterialThemeTest.kt
+++ b/mdc-theme/src/androidTest/java/dev/chrisbanes/accompanist/mdctheme/MaterialThemeTest.kt
@@ -49,6 +49,16 @@ class MaterialThemeTest {
     @get:Rule
     val composeTestRule = AndroidComposeTestRule<MdcActivity>()
 
+    @get:Rule
+    val notMdcComposeTestRule = AndroidComposeTestRule<NotMdcActivity>()
+
+    @Test(expected = IllegalArgumentException::class)
+    fun isNotMaterialTheme() = notMdcComposeTestRule.setContent {
+        MaterialThemeFromMdcTheme {
+            // Nothing to do here, exception should be thrown
+        }
+    }
+
     @Test
     fun colors() = composeTestRule.setContent {
         MaterialThemeFromMdcTheme {

--- a/mdc-theme/src/androidTest/java/dev/chrisbanes/accompanist/mdctheme/NotMdcActivity.kt
+++ b/mdc-theme/src/androidTest/java/dev/chrisbanes/accompanist/mdctheme/NotMdcActivity.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.chrisbanes.accompanist.mdctheme
+
+import androidx.appcompat.app.AppCompatActivity
+
+class NotMdcActivity : AppCompatActivity()

--- a/mdc-theme/src/androidTest/res/values/themes.xml
+++ b/mdc-theme/src/androidTest/res/values/themes.xml
@@ -53,4 +53,6 @@
         <item name="shapeAppearanceLargeComponent">@style/ShapeAppearance.MdcThemeTest.CutNoSize</item>
     </style>
 
+    <style name="Theme.MdcThemeTest.NotMdc" parent="Theme.AppCompat.DayNight" />
+
 </resources>

--- a/mdc-theme/src/main/java/dev/chrisbanes/accompanist/mdctheme/MaterialThemeFromMdcTheme.kt
+++ b/mdc-theme/src/main/java/dev/chrisbanes/accompanist/mdctheme/MaterialThemeFromMdcTheme.kt
@@ -135,7 +135,7 @@ fun generateMaterialThemeFromMdcTheme(
     useTextColors: Boolean = false
 ): Triple<ColorPalette, Typography, Shapes> {
     return context.obtainStyledAttributes(R.styleable.AccompanistMdcTheme).use { ta ->
-        require(ta.hasValue(R.styleable.AccompanistMdcTheme_colorPrimary)) {
+        require(ta.hasValue(R.styleable.AccompanistMdcTheme_isMaterialTheme)) {
             "MaterialThemeUsingMdcTheme requires the host context's theme" +
                 " to extend Theme.MaterialComponents"
         }

--- a/mdc-theme/src/main/res/values/theme_attrs.xml
+++ b/mdc-theme/src/main/res/values/theme_attrs.xml
@@ -18,6 +18,8 @@
 <resources>
 
     <declare-styleable name="AccompanistMdcTheme">
+        <attr name="isMaterialTheme" />
+
         <attr name="colorPrimary" />
         <attr name="colorPrimaryVariant" />
         <attr name="colorOnPrimary" />


### PR DESCRIPTION
This improves the check that requires the context is using a `Theme.MaterialComponents.*` theme. MDC introduced a particular attr for this: [`isMaterialTheme`](https://github.com/material-components/material-components-android/blob/e2eec4aca1795c2795f52098e391c85ccc95a1a4/lib/java/com/google/android/material/color/res/values/attrs.xml#L55).

I considered using [`ThemeEnforcement#obtainStyledAttributes`](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/internal/ThemeEnforcement.java#L67) (which makes use of this attr) but it's quite verbose and is currently restricted to the library group.

A basic test for this was added.

Note: AGP was also updated to 4.2.0-alpha02.