### PR TITLE
Update to Compose SNAPSHOT #6658922

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,9 @@ subprojects {
         mavenCentral()
         jcenter()
 
-        if (Libs.AndroidX.UI.version.endsWith("SNAPSHOT")) {
+        if (Libs.AndroidX.Compose.version.endsWith("SNAPSHOT")) {
             maven {
-                url "https://androidx.dev/snapshots/builds/${Libs.AndroidX.UI.snapshot}/artifacts/ui/repository/"
+                url "https://androidx.dev/snapshots/builds/${Libs.AndroidX.Compose.snapshot}/artifacts/ui/repository/"
             }
         }
     }

--- a/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
@@ -50,27 +50,19 @@ object Libs {
             const val espressoCore = "androidx.test.espresso:espresso-core:3.2.0"
         }
 
-        object UI {
-            const val snapshot = "6602655"
-            const val version = "0.1.0-SNAPSHOT"
-
-            const val core = "androidx.ui:ui-core:$version"
-            const val foundation = "androidx.ui:ui-foundation:$version"
-
-            const val layout = "androidx.ui:ui-layout:$version"
-            const val material = "androidx.ui:ui-material:$version"
-
-            const val animation = "androidx.ui:ui-animation:$version"
-            const val tooling = "androidx.ui:ui-tooling:$version"
-            const val livedata = "androidx.ui:ui-livedata:$version"
-
-            const val test = "androidx.ui:ui-test:$version"
-        }
-
         object Compose {
-            const val version = UI.version
+            const val snapshot = "6658922"
+            const val version = "0.1.0-SNAPSHOT"
+            
             const val kotlinCompilerVersion = "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
+            
             const val runtime = "androidx.compose:compose-runtime:$version"
+            const val core = "androidx.ui:ui-core:${version}"
+            const val foundation = "androidx.compose.foundation:foundation:${version}"
+            const val layout = "androidx.ui:ui-layout:${version}"
+            const val material = "androidx.compose.material:material:${version}"
+            const val tooling = "androidx.compose.tooling:tooling:${version}"
+            const val test = "androidx.compose.test:test-core:${version}"
         }
 
         const val core = "androidx.core:core:1.2.0"

--- a/coil/build.gradle
+++ b/coil/build.gradle
@@ -75,7 +75,7 @@ dependencies {
 
     implementation Libs.AndroidX.coreKtx
     implementation Libs.AndroidX.Compose.runtime
-    implementation Libs.AndroidX.UI.foundation
+    implementation Libs.AndroidX.Compose.foundation
 
     implementation Libs.Kotlin.stdlib
 
@@ -84,8 +84,8 @@ dependencies {
 
     androidTestImplementation Libs.Coroutines.test
 
-    androidTestImplementation Libs.AndroidX.UI.test
-    androidTestImplementation Libs.AndroidX.UI.core
+    androidTestImplementation Libs.AndroidX.Compose.test
+    androidTestImplementation Libs.AndroidX.Compose.core
     androidTestImplementation Libs.AndroidX.Test.rules
     androidTestImplementation Libs.AndroidX.Test.runner
 }

--- a/coil/src/main/java/dev/chrisbanes/accompanist/coil/Coil.kt
+++ b/coil/src/main/java/dev/chrisbanes/accompanist/coil/Coil.kt
@@ -78,8 +78,9 @@ fun CoilImage(
             // pass the request through
             is GetRequest -> data
             // Otherwise we construct a GetRequest using the data parameter
-            else -> remember(data) {
-                GetRequest.Builder(ContextAmbient.current).data(data).build()
+            else -> {
+                val context = ContextAmbient.current
+                remember(data) { GetRequest.Builder(context).data(data).build() }
             }
         },
         alignment = alignment,

--- a/coil/src/main/java/dev/chrisbanes/accompanist/coil/Crossfade.kt
+++ b/coil/src/main/java/dev/chrisbanes/accompanist/coil/Crossfade.kt
@@ -21,10 +21,11 @@ import androidx.animation.AnimationClockObservable
 import androidx.animation.FloatPropKey
 import androidx.animation.createAnimation
 import androidx.animation.transitionDefinition
+import androidx.animation.tween
 import androidx.compose.Composable
-import androidx.compose.NeverEqual
 import androidx.compose.getValue
 import androidx.compose.mutableStateOf
+import androidx.compose.neverEqualPolicy
 import androidx.compose.remember
 import androidx.compose.setValue
 import androidx.core.util.Pools
@@ -47,7 +48,6 @@ import coil.Coil
 import coil.decode.DataSource
 import coil.request.GetRequest
 import coil.request.GetRequestBuilder
-import kotlin.math.roundToInt
 
 private const val DefaultTransitionDuration = 1000
 
@@ -182,7 +182,10 @@ private class ObservableCrossfadeImagePainter(
 
     // Initial matrix is completely transparent. We use the NeverEqual equivalence check since this
     // is a mutable entity.
-    private var matrix by mutableStateOf(ImageLoadingColorMatrix(0f, 0f, 0f), NeverEqual)
+    private var matrix by mutableStateOf(
+        value = ImageLoadingColorMatrix(0f, 0f, 0f),
+        policy = neverEqualPolicy()
+    )
 
     private val animation = CrossfadeTransition.definition(duration).createAnimation(clock)
 
@@ -256,17 +259,12 @@ private object CrossfadeTransition {
         }
 
         transition {
-            Alpha using tween<Float> {
-                // Alpha animation runs over the first 50%
-                duration = durationMs / 2
-            }
-            Brightness using tween<Float> {
-                // Brightness animation runs over the first 75%
-                duration = (durationMs * 0.75f).roundToInt()
-            }
-            Saturation using tween<Float> {
-                duration = durationMs
-            }
+            // Alpha animates over the first 50%
+            Alpha using tween(durationMillis = durationMs / 2)
+            // Brightness animates over the first 75%
+            Brightness using tween(durationMillis = durationMs * 3 / 4)
+            // Saturation animates over whole duration
+            Saturation using tween(durationMillis = durationMs)
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ android.enableJetifier=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=dev.chrisbanes.accompanist
-VERSION_NAME=0.1.7.ui-6602655-SNAPSHOT
+VERSION_NAME=0.1.7.ui-6658828-SNAPSHOT
 
 POM_DESCRIPTION=A collection of utilities for Jetpack Compose
 

--- a/mdc-theme/build.gradle
+++ b/mdc-theme/build.gradle
@@ -68,7 +68,7 @@ android {
 dependencies {
     implementation Libs.AndroidX.coreKtx
     implementation Libs.AndroidX.Compose.runtime
-    implementation Libs.AndroidX.UI.material
+    implementation Libs.AndroidX.Compose.material
 
     implementation Libs.mdc
     // We need to force AppCompat v1.3.0-alpha01 for AppCompatActivity to work with Compose
@@ -77,8 +77,8 @@ dependencies {
     implementation Libs.Kotlin.stdlib
 
     androidTestImplementation Libs.junit
-    androidTestImplementation Libs.AndroidX.UI.test
-    androidTestImplementation Libs.AndroidX.UI.core
+    androidTestImplementation Libs.AndroidX.Compose.test
+    androidTestImplementation Libs.AndroidX.Compose.core
     androidTestImplementation Libs.AndroidX.Test.rules
     androidTestImplementation Libs.AndroidX.Test.runner
 }

--- a/mdc-theme/src/main/java/dev/chrisbanes/accompanist/mdctheme/MaterialThemeFromMdcTheme.kt
+++ b/mdc-theme/src/main/java/dev/chrisbanes/accompanist/mdctheme/MaterialThemeFromMdcTheme.kt
@@ -17,6 +17,7 @@
 package dev.chrisbanes.accompanist.mdctheme
 
 import android.content.Context
+import android.content.res.Configuration
 import android.content.res.Resources
 import android.content.res.TypedArray
 import android.graphics.Typeface
@@ -29,8 +30,6 @@ import androidx.core.content.res.getColorOrThrow
 import androidx.core.content.res.getResourceIdOrThrow
 import androidx.core.content.res.use
 import androidx.ui.core.ContextAmbient
-import androidx.ui.core.DensityAmbient
-import androidx.ui.foundation.isSystemInDarkTheme
 import androidx.ui.foundation.shape.corner.CornerBasedShape
 import androidx.ui.foundation.shape.corner.CornerSize
 import androidx.ui.foundation.shape.corner.CutCornerShape
@@ -94,11 +93,11 @@ fun MaterialThemeFromMdcTheme(
 
     val (colors, type, shapes) = remember(key) {
         generateMaterialThemeFromMdcTheme(
-            context,
-            readColors,
-            readTypography,
-            readShapes,
-            useTextColors
+            context = context,
+            readColors = readColors,
+            readTypography = readTypography,
+            readShapes = readShapes,
+            useTextColors = useTextColors
         )
     }
 
@@ -111,7 +110,7 @@ fun MaterialThemeFromMdcTheme(
 }
 
 /**
- * This effect generates the components of an [androidx.ui.material.MaterialTheme], reading the
+ * This effect generates the components of a [androidx.ui.material.MaterialTheme], reading the
  * values from an Material Design Components Android theme.
  *
  * By default the text colors from any associated `TextAppearance`s from the theme are *not* read.
@@ -120,15 +119,16 @@ fun MaterialThemeFromMdcTheme(
  * You can customize this through the [useTextColors] parameter.
  *
  * @param context The context to read the theme from
+ * @param density The current density
  * @param readColors whether the read the MDC color palette from the context's theme
  * @param readTypography whether the read the MDC typography text appearances from the context's theme
  * @param readShapes whether the read the MDC shape appearances from the context's theme
  * @param useTextColors whether to read the colors from the `TextAppearance`s associated from the
  * theme. Defaults to `false`
  */
-@Composable
 fun generateMaterialThemeFromMdcTheme(
-    context: Context = ContextAmbient.current,
+    context: Context,
+    density: Density = Density(context),
     readColors: Boolean = true,
     readTypography: Boolean = true,
     readShapes: Boolean = true,
@@ -189,7 +189,12 @@ fun generateMaterialThemeFromMdcTheme(
             }
         } else {
             // Else we create an empty color palette based on the configuration's uiMode
-            if (isSystemInDarkTheme()) darkColorPalette() else lightColorPalette()
+            val uiMode = context.resources.configuration.uiMode
+            if ((uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
+                darkColorPalette()
+            } else {
+                lightColorPalette()
+            }
         }
 
         /**
@@ -205,66 +210,79 @@ fun generateMaterialThemeFromMdcTheme(
             typography = typography.merge(
                 h1 = textStyleFromTextAppearance(
                     context,
+                    density,
                     ta.getResourceIdOrThrow(R.styleable.AccompanistMdcTheme_textAppearanceHeadline1),
                     useTextColors
                 ),
                 h2 = textStyleFromTextAppearance(
                     context,
+                    density,
                     ta.getResourceIdOrThrow(R.styleable.AccompanistMdcTheme_textAppearanceHeadline2),
                     useTextColors
                 ),
                 h3 = textStyleFromTextAppearance(
                     context,
+                    density,
                     ta.getResourceIdOrThrow(R.styleable.AccompanistMdcTheme_textAppearanceHeadline3),
                     useTextColors
                 ),
                 h4 = textStyleFromTextAppearance(
                     context,
+                    density,
                     ta.getResourceIdOrThrow(R.styleable.AccompanistMdcTheme_textAppearanceHeadline4),
                     useTextColors
                 ),
                 h5 = textStyleFromTextAppearance(
                     context,
+                    density,
                     ta.getResourceIdOrThrow(R.styleable.AccompanistMdcTheme_textAppearanceHeadline5),
                     useTextColors
                 ),
                 h6 = textStyleFromTextAppearance(
                     context,
+                    density,
                     ta.getResourceIdOrThrow(R.styleable.AccompanistMdcTheme_textAppearanceHeadline6),
                     useTextColors
                 ),
                 subtitle1 = textStyleFromTextAppearance(
                     context,
+                    density,
                     ta.getResourceIdOrThrow(R.styleable.AccompanistMdcTheme_textAppearanceSubtitle1),
                     useTextColors
                 ),
                 subtitle2 = textStyleFromTextAppearance(
                     context,
+                    density,
                     ta.getResourceIdOrThrow(R.styleable.AccompanistMdcTheme_textAppearanceSubtitle2),
                     useTextColors
                 ),
                 body1 = textStyleFromTextAppearance(
                     context,
+                    density,
                     ta.getResourceIdOrThrow(R.styleable.AccompanistMdcTheme_textAppearanceBody1),
                     useTextColors
                 ),
                 body2 = textStyleFromTextAppearance(
                     context,
+                    density,
                     ta.getResourceIdOrThrow(R.styleable.AccompanistMdcTheme_textAppearanceBody2),
                     useTextColors
                 ),
                 button = textStyleFromTextAppearance(
                     context,
+                    density,
                     ta.getResourceIdOrThrow(R.styleable.AccompanistMdcTheme_textAppearanceButton),
                     useTextColors
                 ),
                 caption = textStyleFromTextAppearance(
                     context,
+                    density,
                     ta.getResourceIdOrThrow(R.styleable.AccompanistMdcTheme_textAppearanceCaption),
                     useTextColors
                 ),
                 overline = textStyleFromTextAppearance(
                     context,
+                    density,
                     ta.getResourceIdOrThrow(R.styleable.AccompanistMdcTheme_textAppearanceOverline),
                     useTextColors
                 )
@@ -300,9 +318,9 @@ fun generateMaterialThemeFromMdcTheme(
     }
 }
 
-@Composable
 private fun textStyleFromTextAppearance(
     context: Context,
+    density: Density,
     @StyleRes id: Int,
     useTextColor: Boolean
 ): TextStyle {
@@ -313,8 +331,6 @@ private fun textStyleFromTextAppearance(
 
         // TODO read and expand android:fontVariationSettings.
         // Variable fonts are not supported in Compose yet
-
-        val density = DensityAmbient.current
 
         // FYI, this only works with static font files in assets
         val fontFamilyWeight = when {
@@ -378,7 +394,6 @@ private fun textStyleFromTextAppearance(
     }
 }
 
-@Composable
 private fun readShapeAppearance(
     context: Context,
     @StyleRes id: Int,

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -46,7 +46,7 @@ android {
 
     composeOptions {
         kotlinCompilerVersion Libs.AndroidX.Compose.kotlinCompilerVersion
-        kotlinCompilerExtensionVersion Libs.AndroidX.UI.version
+        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.version
     }
 }
 
@@ -55,9 +55,9 @@ dependencies {
     implementation project(':coil')
 
     implementation Libs.AndroidX.Compose.runtime
-    implementation Libs.AndroidX.UI.material
-    implementation Libs.AndroidX.UI.foundation
-    implementation Libs.AndroidX.UI.layout
+    implementation Libs.AndroidX.Compose.material
+    implementation Libs.AndroidX.Compose.foundation
+    implementation Libs.AndroidX.Compose.layout
 
     implementation Libs.AndroidX.coreKtx
 


### PR DESCRIPTION
Required some changes to `generateMaterialThemeFromMdcTheme()`. Calling composable functions is no longer allowed within `remember {}` calls, so I converted `generateMaterialThemeFromMdcTheme()` to be non-composable. There was no real need for it to be composable, other than convenient access to ambients.