### PR TITLE
Upgrade to Kotlin 1.4.0

### DIFF
--- a/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
@@ -28,7 +28,7 @@ object Libs {
     const val junit = "junit:junit:4.13"
 
     object Kotlin {
-        const val version = "1.4.0-rc"
+        const val version = "1.4.0"
         const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib:$version"
         const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
     }

--- a/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
@@ -34,7 +34,7 @@ object Libs {
     }
 
     object Coroutines {
-        private const val version = "1.3.8-1.4.0-rc"
+        private const val version = "1.3.9"
         const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$version"
         const val test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$version"
     }


### PR DESCRIPTION
Kotlin 1.4.0 is stable, updating to that version.