### PR TITLE
Updates Coil docs to match latest public api

### DIFF
--- a/coil/README.md
+++ b/coil/README.md
@@ -20,7 +20,7 @@ There is also a version of this function which accepts a Coil [`GetRequest`](htt
 
 ```kotlin
 CoilImage(
-    request = GetRequest.Builder(ContextAmbient.current)
+    request = ImageRequest.Builder(ContextAmbient.current)
         .data("https://loremflickr.com/300/300")
         .transformations(CircleCropTransformation())
         .build()


### PR DESCRIPTION
GetRequest and ImageRequest are a single thing now https://github.com/coil-kt/coil/pull/424

Adding this change just because I was about to use it and couldn't copy the snippet on this docs right away.

The only dependency I have is `implementation "dev.chrisbanes.accompanist:accompanist-coil:0.2.1"` (not depending on Coil separately or anything).