### PR TITLE
More API changes

### DIFF
--- a/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
@@ -90,4 +90,6 @@ object Libs {
 
     const val truth = "com.google.truth:truth:1.0.1"
     const val mockk = "io.mockk:mockk-android:1.10.0"
+
+    const val mockWebServer = "com.squareup.okhttp3:mockwebserver:3.12.2"
 }

--- a/coil/api/coil.api
+++ b/coil/api/coil.api
@@ -1,24 +1,52 @@
 public final class dev/chrisbanes/accompanist/coil/CoilImage {
 	public static final fun CoilImage (Lcoil/request/ImageRequest;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;Landroidx/compose/ui/graphics/ColorFilter;ZLcoil/ImageLoader;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun CoilImage (Lcoil/request/ImageRequest;Landroidx/compose/ui/Modifier;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun CoilImage (Lcoil/request/ImageRequest;Landroidx/compose/ui/Modifier;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 	public static final fun CoilImage (Ljava/lang/Object;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;Landroidx/compose/ui/graphics/ColorFilter;ZLcoil/ImageLoader;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun CoilImage (Ljava/lang/Object;Landroidx/compose/ui/Modifier;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun CoilImage (Ljava/lang/Object;Landroidx/compose/ui/Modifier;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 	public static final fun CoilImageWithCrossfade (Lcoil/request/ImageRequest;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;ILcoil/ImageLoader;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun CoilImageWithCrossfade (Ljava/lang/Object;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;ILcoil/ImageLoader;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static fun ErrorResult$annotations ()V
 	public static final fun MaterialLoadingImage (Landroidx/compose/ui/graphics/ImageAsset;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;Landroidx/compose/ui/graphics/ColorFilter;Landroidx/compose/animation/core/AnimationClockObservable;ZILandroidx/compose/runtime/Composer;II)V
-	public static final fun MaterialLoadingImage (Ldev/chrisbanes/accompanist/coil/SuccessResult;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;Landroidx/compose/ui/graphics/ColorFilter;Landroidx/compose/animation/core/AnimationClockObservable;ZZILandroidx/compose/runtime/Composer;II)V
+	public static final fun MaterialLoadingImage (Ldev/chrisbanes/accompanist/coil/CoilImageState$Success;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;Landroidx/compose/ui/graphics/ColorFilter;Landroidx/compose/animation/core/AnimationClockObservable;ZZILandroidx/compose/runtime/Composer;II)V
+	public static fun RequestResult$annotations ()V
+	public static fun SuccessResult$annotations ()V
 }
 
-public final class dev/chrisbanes/accompanist/coil/ErrorResult : dev/chrisbanes/accompanist/coil/RequestResult {
+public abstract class dev/chrisbanes/accompanist/coil/CoilImageState {
+}
+
+public final class dev/chrisbanes/accompanist/coil/CoilImageState$Empty : dev/chrisbanes/accompanist/coil/CoilImageState {
+	public static final field INSTANCE Ldev/chrisbanes/accompanist/coil/CoilImageState$Empty;
+}
+
+public final class dev/chrisbanes/accompanist/coil/CoilImageState$Error : dev/chrisbanes/accompanist/coil/CoilImageState {
 	public fun <init> (Landroidx/compose/ui/graphics/ImageAsset;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Lcoil/request/ErrorResult;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Landroidx/compose/ui/graphics/ImageAsset;
 	public final fun component2 ()Ljava/lang/Throwable;
-	public final fun copy (Landroidx/compose/ui/graphics/ImageAsset;Ljava/lang/Throwable;)Ldev/chrisbanes/accompanist/coil/ErrorResult;
-	public static synthetic fun copy$default (Ldev/chrisbanes/accompanist/coil/ErrorResult;Landroidx/compose/ui/graphics/ImageAsset;Ljava/lang/Throwable;ILjava/lang/Object;)Ldev/chrisbanes/accompanist/coil/ErrorResult;
+	public final fun copy (Landroidx/compose/ui/graphics/ImageAsset;Ljava/lang/Throwable;)Ldev/chrisbanes/accompanist/coil/CoilImageState$Error;
+	public static synthetic fun copy$default (Ldev/chrisbanes/accompanist/coil/CoilImageState$Error;Landroidx/compose/ui/graphics/ImageAsset;Ljava/lang/Throwable;ILjava/lang/Object;)Ldev/chrisbanes/accompanist/coil/CoilImageState$Error;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getImage ()Landroidx/compose/ui/graphics/ImageAsset;
+	public final fun getImage ()Landroidx/compose/ui/graphics/ImageAsset;
 	public final fun getThrowable ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/chrisbanes/accompanist/coil/CoilImageState$Loading : dev/chrisbanes/accompanist/coil/CoilImageState {
+	public static final field INSTANCE Ldev/chrisbanes/accompanist/coil/CoilImageState$Loading;
+}
+
+public final class dev/chrisbanes/accompanist/coil/CoilImageState$Success : dev/chrisbanes/accompanist/coil/CoilImageState {
+	public fun <init> (Landroidx/compose/ui/graphics/ImageAsset;Lcoil/decode/DataSource;)V
+	public synthetic fun <init> (Lcoil/request/SuccessResult;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Landroidx/compose/ui/graphics/ImageAsset;
+	public final fun component2 ()Lcoil/decode/DataSource;
+	public final fun copy (Landroidx/compose/ui/graphics/ImageAsset;Lcoil/decode/DataSource;)Ldev/chrisbanes/accompanist/coil/CoilImageState$Success;
+	public static synthetic fun copy$default (Ldev/chrisbanes/accompanist/coil/CoilImageState$Success;Landroidx/compose/ui/graphics/ImageAsset;Lcoil/decode/DataSource;ILjava/lang/Object;)Ldev/chrisbanes/accompanist/coil/CoilImageState$Success;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getImage ()Landroidx/compose/ui/graphics/ImageAsset;
+	public final fun getSource ()Lcoil/decode/DataSource;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -33,23 +61,5 @@ public final class dev/chrisbanes/accompanist/coil/ImageLoadingColorMatrix : and
 	public final fun setAlphaFraction (F)V
 	public final fun setBrightnessFraction (F)V
 	public final fun setSaturationFraction (F)V
-}
-
-public abstract class dev/chrisbanes/accompanist/coil/RequestResult {
-	public abstract fun getImage ()Landroidx/compose/ui/graphics/ImageAsset;
-}
-
-public final class dev/chrisbanes/accompanist/coil/SuccessResult : dev/chrisbanes/accompanist/coil/RequestResult {
-	public fun <init> (Landroidx/compose/ui/graphics/ImageAsset;Lcoil/decode/DataSource;)V
-	public synthetic fun <init> (Lcoil/request/SuccessResult;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Landroidx/compose/ui/graphics/ImageAsset;
-	public final fun component2 ()Lcoil/decode/DataSource;
-	public final fun copy (Landroidx/compose/ui/graphics/ImageAsset;Lcoil/decode/DataSource;)Ldev/chrisbanes/accompanist/coil/SuccessResult;
-	public static synthetic fun copy$default (Ldev/chrisbanes/accompanist/coil/SuccessResult;Landroidx/compose/ui/graphics/ImageAsset;Lcoil/decode/DataSource;ILjava/lang/Object;)Ldev/chrisbanes/accompanist/coil/SuccessResult;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getImage ()Landroidx/compose/ui/graphics/ImageAsset;
-	public final fun getSource ()Lcoil/decode/DataSource;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 

--- a/coil/build.gradle
+++ b/coil/build.gradle
@@ -92,6 +92,8 @@ dependencies {
     androidTestImplementation Libs.truth
     androidTestImplementation Libs.mockk
 
+    androidTestImplementation Libs.mockWebServer
+
     androidTestImplementation Libs.Coroutines.test
 
     androidTestImplementation Libs.AndroidX.Compose.test

--- a/coil/src/androidTest/AndroidManifest.xml
+++ b/coil/src/androidTest/AndroidManifest.xml
@@ -20,7 +20,13 @@
 
     <uses-sdk android:targetSdkVersion="29" />
 
-    <application>
+    <!-- Needed for MockWebServer -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- usesCleartextTraffic=true because we use MockWebServer -->
+    <application
+        android:name="dev.chrisbanes.accompanist.coil.CoilTestApplication"
+        android:usesCleartextTraffic="true">
         <activity
             android:name="androidx.activity.ComponentActivity"
             android:theme="@style/Theme.CoilTest"

--- a/coil/src/androidTest/java/dev/chrisbanes/accompanist/coil/CoilTest.kt
+++ b/coil/src/androidTest/java/dev/chrisbanes/accompanist/coil/CoilTest.kt
@@ -78,7 +78,8 @@ class CoilTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    private val server = coilTestWebServer()
+    // Our MockWebServer. We use a response delay to simulate real-world conditions
+    private val server = coilTestWebServer(responseDelayMs = 200)
 
     @Before
     fun setup() {
@@ -485,7 +486,7 @@ private fun resourceUri(id: Int): Uri {
  * [MockWebServer] which returns a valid at the path `/image` and a 404 for anything else.
  * We add a small delay to simulate 'real-world' network conditions.
  */
-private fun coilTestWebServer(): MockWebServer {
+private fun coilTestWebServer(responseDelayMs: Long = 0): MockWebServer {
     val dispatcher = object : Dispatcher() {
         override fun dispatch(request: RecordedRequest): MockResponse = when (request.path) {
             "/image" -> {
@@ -497,10 +498,14 @@ private fun coilTestWebServer(): MockWebServer {
                 }
 
                 MockResponse()
+                    .setHeadersDelay(responseDelayMs, TimeUnit.MILLISECONDS)
                     .addHeader("Content-Type", "image/jpeg")
                     .setBody(imageBuffer)
             }
-            else -> MockResponse().setResponseCode(404)
+            else ->
+                MockResponse()
+                    .setHeadersDelay(responseDelayMs, TimeUnit.MILLISECONDS)
+                    .setResponseCode(404)
         }
     }
 

--- a/coil/src/androidTest/java/dev/chrisbanes/accompanist/coil/CoilTest.kt
+++ b/coil/src/androidTest/java/dev/chrisbanes/accompanist/coil/CoilTest.kt
@@ -483,7 +483,7 @@ private fun resourceUri(id: Int): Uri {
 }
 
 /**
- * [MockWebServer] which returns a valid at the path `/image` and a 404 for anything else.
+ * [MockWebServer] which returns a valid response at the path `/image`, and a 404 for anything else.
  * We add a small delay to simulate 'real-world' network conditions.
  */
 private fun coilTestWebServer(responseDelayMs: Long = 0): MockWebServer {

--- a/coil/src/androidTest/java/dev/chrisbanes/accompanist/coil/CoilTest.kt
+++ b/coil/src/androidTest/java/dev/chrisbanes/accompanist/coil/CoilTest.kt
@@ -74,7 +74,7 @@ class CoilTest {
 
     @Test
     fun onRequestCompleted() {
-        val results = ArrayList<RequestResult>()
+        val results = ArrayList<CoilImageState>()
         val latch = CountDownLatch(1)
 
         composeTestRule.setContent {
@@ -94,7 +94,7 @@ class CoilTest {
         composeTestRule.runOnIdle {
             // And assert that we got a single successful result
             assertThat(results).hasSize(1)
-            assertThat(results[0]).isInstanceOf(SuccessResult::class.java)
+            assertThat(results[0]).isInstanceOf(CoilImageState.Success::class.java)
         }
     }
 
@@ -281,13 +281,12 @@ class CoilTest {
         composeTestRule.setContent {
             CoilImage(
                 data = resourceUri(R.raw.sample),
-                image = {
-                    // Return an Image which just draws cyan
-                    Image(painter = ColorPainter(Color.Cyan))
-                },
                 modifier = Modifier.preferredSize(128.dp, 128.dp).testTag(CoilTestTags.Image),
                 onRequestCompleted = { latch.countDown() }
-            )
+            ) { _ ->
+                // Return an Image which just draws cyan
+                Image(painter = ColorPainter(Color.Cyan))
+            }
         }
 
         // Wait for the onRequestCompleted to release the latch

--- a/coil/src/androidTest/java/dev/chrisbanes/accompanist/coil/CoilTestApplication.kt
+++ b/coil/src/androidTest/java/dev/chrisbanes/accompanist/coil/CoilTestApplication.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.chrisbanes.accompanist.coil
+
+import android.app.Application
+import android.os.StrictMode
+
+class CoilTestApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        // CoilTest uses MockWebServer.url() which internally does a network check, and
+        // triggers StrictMode. To workaround that in the tests, we allow network on main thread.
+        val threadPolicy = StrictMode.ThreadPolicy.Builder()
+            .detectAll()
+            .permitNetwork()
+            .build()
+        StrictMode.setThreadPolicy(threadPolicy)
+    }
+}

--- a/coil/src/androidTest/java/dev/chrisbanes/accompanist/coil/CoilTestApplication.kt
+++ b/coil/src/androidTest/java/dev/chrisbanes/accompanist/coil/CoilTestApplication.kt
@@ -16,19 +16,41 @@
 
 package dev.chrisbanes.accompanist.coil
 
+import android.app.Activity
 import android.app.Application
+import android.os.Bundle
 import android.os.StrictMode
 
 class CoilTestApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        // CoilTest uses MockWebServer.url() which internally does a network check, and
-        // triggers StrictMode. To workaround that in the tests, we allow network on main thread.
-        val threadPolicy = StrictMode.ThreadPolicy.Builder()
-            .detectAll()
-            .permitNetwork()
-            .build()
-        StrictMode.setThreadPolicy(threadPolicy)
+        registerActivityLifecycleCallbacks(
+            object : DefaultActivityLifecycleCallbacks {
+                override fun onActivityCreated(activity: Activity, savedState: Bundle?) {
+                    // [CoilTest] uses MockWebServer.url() which internally does a network check,
+                    // and triggers StrictMode. To workaround that in the tests, we allow network
+                    // on main thread.
+                    val threadPolicy = StrictMode.ThreadPolicy.Builder()
+                        .detectAll()
+                        .permitNetwork()
+                        .build()
+                    StrictMode.setThreadPolicy(threadPolicy)
+                }
+            }
+        )
     }
+}
+
+/**
+ * [Application.ActivityLifecycleCallbacks] which adds default empty method implementations.
+ */
+private interface DefaultActivityLifecycleCallbacks : Application.ActivityLifecycleCallbacks {
+    override fun onActivityCreated(activity: Activity, savedState: Bundle?) = Unit
+    override fun onActivityStarted(activity: Activity) = Unit
+    override fun onActivityResumed(activity: Activity) = Unit
+    override fun onActivityPaused(activity: Activity) = Unit
+    override fun onActivityStopped(activity: Activity) = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, savedState: Bundle) = Unit
+    override fun onActivityDestroyed(activity: Activity) = Unit
 }

--- a/coil/src/main/java/dev/chrisbanes/accompanist/coil/Coil.kt
+++ b/coil/src/main/java/dev/chrisbanes/accompanist/coil/Coil.kt
@@ -54,8 +54,8 @@ import coil.request.ImageResult
  * ```
  * CoilImage(
  *   data = "https://www.image.url",
- * ) { state ->
- *   when (state) {
+ * ) { imageState ->
+ *   when (imageState) {
  *     is CoilImageState.Success -> // TODO
  *     is CoilImageState.Error -> // TODO
  *     CoilImageState.Loading -> // TODO
@@ -80,7 +80,7 @@ fun CoilImage(
     imageLoader: ImageLoader = Coil.imageLoader(ContextAmbient.current),
     shouldRefetchOnSizeChange: (currentResult: CoilImageState, size: IntSize) -> Boolean = defaultRefetchOnSizeChangeLambda,
     onRequestCompleted: (CoilImageState) -> Unit = emptySuccessLambda,
-    content: @Composable (state: CoilImageState) -> Unit
+    content: @Composable (imageState: CoilImageState) -> Unit
 ) {
     CoilImage(
         request = data.toImageRequest(),
@@ -99,8 +99,8 @@ fun CoilImage(
  * ```
  * CoilImage(
  *   request = ImageRequest.Builder(context).data(...).build(),
- * ) { state ->
- *   when (state) {
+ * ) { imageState ->
+ *   when (imageState) {
  *     is CoilImageState.Success -> // TODO
  *     is CoilImageState.Error -> // TODO
  *     CoilImageState.Loading -> // TODO
@@ -126,7 +126,7 @@ fun CoilImage(
     imageLoader: ImageLoader = Coil.imageLoader(ContextAmbient.current),
     shouldRefetchOnSizeChange: (currentResult: CoilImageState, size: IntSize) -> Boolean = defaultRefetchOnSizeChangeLambda,
     onRequestCompleted: (CoilImageState) -> Unit = emptySuccessLambda,
-    content: @Composable (state: CoilImageState) -> Unit
+    content: @Composable (imageState: CoilImageState) -> Unit
 ) {
     var state by stateFor<CoilImageState>(request) { CoilImageState.Empty }
 
@@ -313,18 +313,18 @@ fun CoilImage(
         imageLoader = imageLoader,
         shouldRefetchOnSizeChange = shouldRefetchOnSizeChange,
         onRequestCompleted = onRequestCompleted,
-    ) { state ->
-        when (state) {
+    ) { imageState ->
+        when (imageState) {
             is CoilImageState.Success -> {
                 MaterialLoadingImage(
-                    result = state,
+                    result = imageState,
                     fadeInEnabled = fadeIn,
                     alignment = alignment,
                     contentScale = contentScale,
                     colorFilter = colorFilter
                 )
             }
-            is CoilImageState.Error -> if (error != null) error(state)
+            is CoilImageState.Error -> if (error != null) error(imageState)
             CoilImageState.Loading -> if (loading != null) loading()
             CoilImageState.Empty -> Unit
         }
@@ -363,13 +363,13 @@ private fun CoilRequestActor(
         imageLoader
             .execute(transformedRequest)
             .toResult(size)
-            .also { state ->
+            .also { imageState ->
                 // Tell RenderThread to pre-upload this bitmap. Saves the GPU upload cost on the
                 // first draw. See https://github.com/square/picasso/issues/1620 for a explanation
                 // from @ChrisCraik
-                when (state) {
-                    is CoilImageState.Success -> state.image.prepareToDraw()
-                    is CoilImageState.Error -> state.image?.prepareToDraw()
+                when (imageState) {
+                    is CoilImageState.Success -> imageState.image.prepareToDraw()
+                    is CoilImageState.Error -> imageState.image?.prepareToDraw()
                 }
             }
             .also { state ->

--- a/coil/src/main/java/dev/chrisbanes/accompanist/coil/Crossfade.kt
+++ b/coil/src/main/java/dev/chrisbanes/accompanist/coil/Crossfade.kt
@@ -150,18 +150,18 @@ fun CoilImageWithCrossfade(
         shouldRefetchOnSizeChange = shouldRefetchOnSizeChange,
         modifier = modifier,
         onRequestCompleted = onRequestCompleted,
-    ) { state ->
-        when (state) {
+    ) { imageState ->
+        when (imageState) {
             is CoilImageState.Success -> {
                 MaterialLoadingImage(
-                    result = state,
+                    result = imageState,
                     fadeInEnabled = true,
                     fadeInDurationMs = crossfadeDuration,
                     alignment = alignment,
                     contentScale = contentScale,
                 )
             }
-            is CoilImageState.Error -> if (error != null) error(state)
+            is CoilImageState.Error -> if (error != null) error(imageState)
             CoilImageState.Loading -> if (loading != null) loading()
             CoilImageState.Empty -> Unit
         }

--- a/coil/src/main/java/dev/chrisbanes/accompanist/coil/RequestActor.kt
+++ b/coil/src/main/java/dev/chrisbanes/accompanist/coil/RequestActor.kt
@@ -54,7 +54,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
  * ```
  */
 internal class RequestActor<Param, Result>(
-    private val execute: suspend (Param) -> Result
+    private val execute: suspend (Param, onResult: (Result) -> Unit) -> Unit
 ) {
     private val channel = Channel<Param>(Channel.CONFLATED)
 
@@ -69,7 +69,9 @@ internal class RequestActor<Param, Result>(
     suspend fun run(onResult: (Param, Result) -> Unit) {
         channel.receiveAsFlow()
             .distinctUntilChanged()
-            .collect { input -> onResult(input, execute(input)) }
+            .collect { input ->
+                execute(input) { result -> onResult(input, result) }
+            }
     }
 
     /**

--- a/sample/src/main/java/dev/chrisbanes/accompanist/sample/coil/CoilBasicSample.kt
+++ b/sample/src/main/java/dev/chrisbanes/accompanist/sample/coil/CoilBasicSample.kt
@@ -92,12 +92,12 @@ private fun Sample() {
                 // CoilImage with loading slot
                 CoilImage(
                     data = randomSampleImageUrl(),
-                    fadeIn = true,
                     loading = {
                         Stack(Modifier.fillMaxSize()) {
                             CircularProgressIndicator(Modifier.align(Alignment.Center))
                         }
-                    }
+                    },
+                    modifier = Modifier.preferredSize(128.dp)
                 )
 
                 // CoilImage with crossfade and data parameter

--- a/sample/src/main/java/dev/chrisbanes/accompanist/sample/coil/CoilBasicSample.kt
+++ b/sample/src/main/java/dev/chrisbanes/accompanist/sample/coil/CoilBasicSample.kt
@@ -92,12 +92,12 @@ private fun Sample() {
                 // CoilImage with loading slot
                 CoilImage(
                     data = randomSampleImageUrl(),
+                    fadeIn = true,
                     loading = {
                         Stack(Modifier.fillMaxSize()) {
                             CircularProgressIndicator(Modifier.align(Alignment.Center))
                         }
-                    },
-                    modifier = Modifier.preferredSize(128.dp)
+                    }
                 )
 
                 // CoilImage with crossfade and data parameter


### PR DESCRIPTION
As we're on a roll of API changes, here's one final change:

- `SuccessResult` and `ErrorResult` have now been expanded in the sealed `CoilImageState`, which now contains: `Success`, `Error`, `Loading` & `Empty`
- The recent `CoilImage` with the `image` composable has been expanded and made more flexible:

``` kotlin
CoilImage(
  data = "https://www.image.url",
) { state ->
  when (state) {
    is CoilImageState.Success -> // TODO
    is CoilImageState.Error -> // TODO
    CoilImageState.Loading -> // TODO
    CoilImageState.Empty -> // TODO
  }
}
```

The more opinionated (and easier to use) version which hosts content slots still exists, allowing:

``` kotlin
CoilImage(
  data = "https://www.image.url",
  fadeIn = true,
  loading = { /* content to show while loading */ },
  error = { /* content to show when an error has occurred */ }
)
```

- The tests have been revamped, using [MockWebServer](https://square.github.io/okhttp/4.x/mockwebserver/okhttp3.mockwebserver/-mock-web-server/) to serve the images in a more realistic way.

Closes #92