### PR TITLE
Fix PicassoImage not maintaining aspect ratio when resizing

### DIFF
--- a/picasso/src/main/java/dev/chrisbanes/accompanist/picasso/Picasso.kt
+++ b/picasso/src/main/java/dev/chrisbanes/accompanist/picasso/Picasso.kt
@@ -127,7 +127,16 @@ fun PicassoImage(
                 // in the Coil request
                 size.width < 0 || size.height < 0 -> r
                 // If we have a non-zero size, we can modify the request to include the size
-                size != IntSize.Zero -> r.resize(size.width, size.height).onlyScaleDown()
+                size != IntSize.Zero -> {
+                    // We use centerInside() here, otherwise Picasso will resize the image ignoring
+                    // aspect ratio. centerInside() isn't great, since it means that the image
+                    // could be loaded smaller than the composable, only to be scaled up again by
+                    // the chosen ContentScale. Unfortunately there's not much else we can do.
+                    // See https://github.com/chrisbanes/accompanist/issues/118
+                    r.resize(size.width, size.height)
+                        .centerInside()
+                        .onlyScaleDown()
+                }
                 // Otherwise we have a zero size, so no point executing a request
                 else -> null
             }

--- a/sample/src/main/java/dev/chrisbanes/accompanist/sample/coil/CoilBasicSample.kt
+++ b/sample/src/main/java/dev/chrisbanes/accompanist/sample/coil/CoilBasicSample.kt
@@ -25,9 +25,11 @@ import androidx.compose.foundation.Text
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayout
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredSize
+import androidx.compose.foundation.layout.preferredWidth
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
@@ -35,6 +37,7 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ContextAmbient
 import androidx.compose.ui.platform.setContent
 import androidx.compose.ui.res.stringResource
@@ -154,6 +157,14 @@ private fun Sample() {
                             CircularProgressIndicator(Modifier.align(Alignment.Center))
                         }
                     }
+                )
+
+                // CoilImage with an aspect ratio and crop scale
+                CoilImage(
+                    data = randomSampleImageUrl(),
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.preferredWidth(256.dp)
+                        .aspectRatio(16 / 9f)
                 )
             }
         }

--- a/sample/src/main/java/dev/chrisbanes/accompanist/sample/picasso/PicassoBasicSample.kt
+++ b/sample/src/main/java/dev/chrisbanes/accompanist/sample/picasso/PicassoBasicSample.kt
@@ -23,9 +23,11 @@ import androidx.compose.foundation.Text
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayout
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.preferredSize
+import androidx.compose.foundation.layout.preferredWidth
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
@@ -33,6 +35,7 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.setContent
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -112,7 +115,7 @@ private fun Sample() {
                     modifier = Modifier.preferredSize(128.dp)
                 )
 
-                // PicassoImage with an implicit size
+                // PicassoImage with an implicit size and loading slot
                 PicassoImage(
                     data = randomSampleImageUrl(),
                     loading = {
@@ -120,6 +123,14 @@ private fun Sample() {
                             CircularProgressIndicator(Modifier.align(Alignment.Center))
                         }
                     }
+                )
+
+                // PicassoImage with an aspect ratio
+                PicassoImage(
+                    data = randomSampleImageUrl(),
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.preferredWidth(256.dp)
+                        .aspectRatio(16 / 9f)
                 )
             }
         }


### PR DESCRIPTION
We now use `centerInside()` which maintains aspect ratio, but could lead to images being scaled smaller than the composable.

Closes #118 