### PR TITLE
De-flake `loading_slot` tests

### DIFF
--- a/picasso/build.gradle
+++ b/picasso/build.gradle
@@ -95,8 +95,6 @@ dependencies {
 
     androidTestImplementation Libs.OkHttp.mockWebServer
 
-    androidTestImplementation Libs.Coroutines.test
-
     androidTestImplementation Libs.AndroidX.Compose.test
     androidTestImplementation Libs.AndroidX.Compose.ui
     androidTestImplementation Libs.AndroidX.Test.rules

--- a/picasso/src/androidTest/java/dev/chrisbanes/accompanist/picasso/SingleThreadPauseableExecutor.kt
+++ b/picasso/src/androidTest/java/dev/chrisbanes/accompanist/picasso/SingleThreadPauseableExecutor.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.chrisbanes.accompanist.picasso
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ * This is copied from the javadoc on [ThreadPoolExecutor].
+ */
+internal class SingleThreadPausableExecutor(paused: Boolean = false) : ThreadPoolExecutor(
+    1, 1, 0L, TimeUnit.MILLISECONDS, LinkedBlockingQueue()
+) {
+    private var isPaused = paused
+    private val pauseLock = ReentrantLock()
+    private val unpaused = pauseLock.newCondition()
+
+    override fun beforeExecute(t: Thread, r: Runnable) {
+        super.beforeExecute(t, r)
+        pauseLock.lock()
+        try {
+            while (isPaused) unpaused.await()
+        } catch (ie: InterruptedException) {
+            t.interrupt()
+        } finally {
+            pauseLock.unlock()
+        }
+    }
+
+    fun pause() {
+        pauseLock.lock()
+        try {
+            isPaused = true
+        } finally {
+            pauseLock.unlock()
+        }
+    }
+
+    fun resume() {
+        pauseLock.lock()
+        try {
+            isPaused = false
+            unpaused.signalAll()
+        } finally {
+            pauseLock.unlock()
+        }
+    }
+}


### PR DESCRIPTION
We now follow the same pattern across the libraries, of injecting a pauseable 'runner' (executor, dispatcher) and then resuming once we're ready.

Closes #105 