### PR TITLE
Make upload to Sonatype less flaky

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,11 @@ jobs:
           key: gradle-${{ hashFiles('checksum.txt') }}
 
       - name: Deploy to Sonatype
-        run: ./gradlew uploadArchives --no-parallel
+        # We manually run assemble & dokka before uploadArchives. If we only run uploadArchives,
+        # the assemble and dokka tasks are run interleaved on each module, which can cause
+        # connection timeouts to Sonatype (since we need to wait for assemble+dokka to finish).
+        # By front-loading the assemble+dokka tasks, the upload is much quicker.
+        run: ./gradlew assembleRelease dokkaHtml uploadArchives --no-parallel
         env:
           SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}


### PR DESCRIPTION
We now manually run assemble & dokka before `uploadArchives`. If we only run `uploadArchives`, the assemble and dokka tasks are run interleaved on each module, which can cause connection timeouts to Sonatype (since we need to wait for assemble+dokka to finish).

By front-loading the assemble+dokka tasks, the upload itself is much quicker, and less likely to timeout.

Raised: https://github.com/vanniktech/gradle-maven-publish-plugin/issues/170