### PR TITLE
[Image Loading] Skip initial `Empty` state

### DIFF
--- a/coil/src/androidTest/java/dev/chrisbanes/accompanist/coil/CoilTest.kt
+++ b/coil/src/androidTest/java/dev/chrisbanes/accompanist/coil/CoilTest.kt
@@ -399,10 +399,10 @@ class CoilTest {
         latch.await(5, TimeUnit.SECONDS)
 
         composeTestRule.runOnIdle {
-            assertThat(states).hasSize(3)
-            assertThat(states[0]).isEqualTo(ImageLoadState.Empty)
-            assertThat(states[1]).isEqualTo(ImageLoadState.Loading)
-            assertThat(states[2]).isInstanceOf(ImageLoadState.Error::class.java)
+            assertThat(states).hasSize(2)
+
+            assertThat(states[0]).isEqualTo(ImageLoadState.Loading)
+            assertThat(states[1]).isInstanceOf(ImageLoadState.Error::class.java)
         }
     }
 
@@ -428,10 +428,9 @@ class CoilTest {
         latch.await(5, TimeUnit.SECONDS)
 
         composeTestRule.runOnIdle {
-            assertThat(states).hasSize(3)
-            assertThat(states[0]).isEqualTo(ImageLoadState.Empty)
-            assertThat(states[1]).isEqualTo(ImageLoadState.Loading)
-            assertThat(states[2]).isInstanceOf(ImageLoadState.Success::class.java)
+            assertThat(states).hasSize(2)
+            assertThat(states[0]).isEqualTo(ImageLoadState.Loading)
+            assertThat(states[1]).isInstanceOf(ImageLoadState.Success::class.java)
         }
     }
 

--- a/glide/src/androidTest/java/dev/chrisbanes/accompanist/glide/GlideTest.kt
+++ b/glide/src/androidTest/java/dev/chrisbanes/accompanist/glide/GlideTest.kt
@@ -378,10 +378,9 @@ class GlideTest {
         latch.await(5, TimeUnit.SECONDS)
 
         composeTestRule.runOnIdle {
-            assertThat(states).hasSize(3)
-            assertThat(states[0]).isEqualTo(ImageLoadState.Empty)
-            assertThat(states[1]).isEqualTo(ImageLoadState.Loading)
-            assertThat(states[2]).isInstanceOf(ImageLoadState.Error::class.java)
+            assertThat(states).hasSize(2)
+            assertThat(states[0]).isEqualTo(ImageLoadState.Loading)
+            assertThat(states[1]).isInstanceOf(ImageLoadState.Error::class.java)
         }
     }
 
@@ -409,10 +408,9 @@ class GlideTest {
         latch.await(5, TimeUnit.SECONDS)
 
         composeTestRule.runOnIdle {
-            assertThat(states).hasSize(3)
-            assertThat(states[0]).isEqualTo(ImageLoadState.Empty)
-            assertThat(states[1]).isEqualTo(ImageLoadState.Loading)
-            assertThat(states[2]).isInstanceOf(ImageLoadState.Success::class.java)
+            assertThat(states).hasSize(2)
+            assertThat(states[0]).isEqualTo(ImageLoadState.Loading)
+            assertThat(states[1]).isInstanceOf(ImageLoadState.Success::class.java)
         }
     }
 

--- a/imageloading-core/src/main/java/dev/chrisbanes/accompanist/imageloading/ImageLoad.kt
+++ b/imageloading-core/src/main/java/dev/chrisbanes/accompanist/imageloading/ImageLoad.kt
@@ -68,7 +68,8 @@ fun <R : Any, TR : Any> ImageLoad(
     content: @Composable (imageLoadState: ImageLoadState) -> Unit
 ) {
     var state by remember(requestKey) {
-        mutableStateOf<ImageLoadState>(ImageLoadState.Empty)
+        // We start from the loading state, to avoid thrashing from empty -> loading straightaway
+        mutableStateOf<ImageLoadState>(ImageLoadState.Loading)
     }
 
     // This may look a little weird, but allows the LaunchedEffect callback to always

--- a/picasso/src/androidTest/java/dev/chrisbanes/accompanist/picasso/PicassoTest.kt
+++ b/picasso/src/androidTest/java/dev/chrisbanes/accompanist/picasso/PicassoTest.kt
@@ -343,10 +343,9 @@ class PicassoTest {
         latch.await(5, TimeUnit.SECONDS)
 
         composeTestRule.runOnIdle {
-            assertThat(states).hasSize(3)
-            assertThat(states[0]).isEqualTo(ImageLoadState.Empty)
-            assertThat(states[1]).isEqualTo(ImageLoadState.Loading)
-            assertThat(states[2]).isInstanceOf(ImageLoadState.Error::class.java)
+            assertThat(states).hasSize(2)
+            assertThat(states[0]).isEqualTo(ImageLoadState.Loading)
+            assertThat(states[1]).isInstanceOf(ImageLoadState.Error::class.java)
         }
     }
 
@@ -375,10 +374,9 @@ class PicassoTest {
         latch.await(5, TimeUnit.SECONDS)
 
         composeTestRule.runOnIdle {
-            assertThat(states).hasSize(3)
-            assertThat(states[0]).isEqualTo(ImageLoadState.Empty)
-            assertThat(states[1]).isEqualTo(ImageLoadState.Loading)
-            assertThat(states[2]).isInstanceOf(ImageLoadState.Success::class.java)
+            assertThat(states).hasSize(2)
+            assertThat(states[0]).isEqualTo(ImageLoadState.Loading)
+            assertThat(states[1]).isInstanceOf(ImageLoadState.Success::class.java)
         }
     }
 


### PR DESCRIPTION
We now start from the Loading state, since we switch instantly to Loading in 99% of cases. This means we no longer display the Empty state as start before switching to Loading one composition later.

We now treat Empty as a terminal/result state.

Closes #141