### PR TITLE
Add ViewWindowInsetObserver

### DIFF
--- a/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
@@ -86,6 +86,10 @@ object Libs {
         const val core = "androidx.core:core:1.2.0"
         const val coreKtx = "androidx.core:core-ktx:1.2.0"
 
+        const val fragmentKtx = "androidx.fragment:fragment-ktx:1.3.0-beta01"
+
+        const val lifecycleKtx = "androidx.lifecycle:lifecycle-runtime-ktx:2.3.0-beta01"
+
         const val coreAlpha = "androidx.core:core:1.5.0-alpha04"
     }
 

--- a/insets/api/insets.api
+++ b/insets/api/insets.api
@@ -9,6 +9,8 @@ public final class dev/chrisbanes/accompanist/insets/ComposeInsets {
 	public static final fun navigationBarsPadding$default (Landroidx/compose/ui/Modifier;ZZZILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 	public static final fun navigationBarsWidth-UTaBBDU (Landroidx/compose/ui/Modifier;Ldev/chrisbanes/accompanist/insets/HorizontalSide;F)Landroidx/compose/ui/Modifier;
 	public static final fun navigationBarsWidth-UTaBBDU$default (Landroidx/compose/ui/Modifier;Ldev/chrisbanes/accompanist/insets/HorizontalSide;FILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+	public static final fun observeFromView (Ldev/chrisbanes/accompanist/insets/WindowInsets;Landroid/view/View;Z)Lkotlin/jvm/functions/Function0;
+	public static final fun observeFromView$default (Ldev/chrisbanes/accompanist/insets/WindowInsets;Landroid/view/View;ZILjava/lang/Object;)Lkotlin/jvm/functions/Function0;
 	public static final fun statusBarsHeight-wxomhCo (Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;
 	public static final fun statusBarsHeight-wxomhCo$default (Landroidx/compose/ui/Modifier;FILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 	public static final fun statusBarsPadding (Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;

--- a/insets/api/insets.api
+++ b/insets/api/insets.api
@@ -9,8 +9,6 @@ public final class dev/chrisbanes/accompanist/insets/ComposeInsets {
 	public static final fun navigationBarsPadding$default (Landroidx/compose/ui/Modifier;ZZZILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 	public static final fun navigationBarsWidth-UTaBBDU (Landroidx/compose/ui/Modifier;Ldev/chrisbanes/accompanist/insets/HorizontalSide;F)Landroidx/compose/ui/Modifier;
 	public static final fun navigationBarsWidth-UTaBBDU$default (Landroidx/compose/ui/Modifier;Ldev/chrisbanes/accompanist/insets/HorizontalSide;FILjava/lang/Object;)Landroidx/compose/ui/Modifier;
-	public static final fun observeFromView (Ldev/chrisbanes/accompanist/insets/WindowInsets;Landroid/view/View;Z)Lkotlin/jvm/functions/Function0;
-	public static final fun observeFromView$default (Ldev/chrisbanes/accompanist/insets/WindowInsets;Landroid/view/View;ZILjava/lang/Object;)Lkotlin/jvm/functions/Function0;
 	public static final fun statusBarsHeight-wxomhCo (Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;
 	public static final fun statusBarsHeight-wxomhCo$default (Landroidx/compose/ui/Modifier;FILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 	public static final fun statusBarsPadding (Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;
@@ -40,6 +38,15 @@ public final class dev/chrisbanes/accompanist/insets/VerticalSide : java/lang/En
 	public static final field Top Ldev/chrisbanes/accompanist/insets/VerticalSide;
 	public static final fun valueOf (Ljava/lang/String;)Ldev/chrisbanes/accompanist/insets/VerticalSide;
 	public static final fun values ()[Ldev/chrisbanes/accompanist/insets/VerticalSide;
+}
+
+public final class dev/chrisbanes/accompanist/insets/ViewWindowInsetObserver {
+	public static final field $stable I
+	public fun <init> (Landroid/view/View;)V
+	public final fun isObserving ()Z
+	public final fun start (Z)Ldev/chrisbanes/accompanist/insets/WindowInsets;
+	public static synthetic fun start$default (Ldev/chrisbanes/accompanist/insets/ViewWindowInsetObserver;ZILjava/lang/Object;)Ldev/chrisbanes/accompanist/insets/WindowInsets;
+	public final fun stop ()V
 }
 
 public final class dev/chrisbanes/accompanist/insets/WindowInsets {

--- a/insets/src/main/java/dev/chrisbanes/accompanist/insets/Insets.kt
+++ b/insets/src/main/java/dev/chrisbanes/accompanist/insets/Insets.kt
@@ -130,7 +130,7 @@ val AmbientWindowInsets = staticAmbientOf<WindowInsets> {
  *
  *     // Call start() to start listening now.
  *     // The WindowInsets instance is returned to us.
- *     val windowInsets = observer.observe()
+ *     val windowInsets = observer.start()
  *
  *     setContent {
  *         // Instead of calling ProvideWindowInsets, we use Providers to provide

--- a/insets/src/main/java/dev/chrisbanes/accompanist/insets/Insets.kt
+++ b/insets/src/main/java/dev/chrisbanes/accompanist/insets/Insets.kt
@@ -109,10 +109,9 @@ val AmbientWindowInsets = staticAmbientOf<WindowInsets> {
  * [WindowInsetsCompat] instance dispatched by the system.
  *
  * This function is useful for when you prefer to handle the ownership of the [WindowInsets]
- * yourself. One example of this is if you find yourself using [ProvideWindowInsets] in multiple
- * fragments.
+ * yourself. One example of this is if you find yourself using [ProvideWindowInsets] in fragments.
  *
- * It is convenient to use [ProvideWindowInsets] in each fragment, but that can result in a
+ * It is convenient to use [ProvideWindowInsets] in a fragment, but that can result in a
  * delay in the initial inset update, which results in a visual flicker.
  * See [this issue](https://github.com/chrisbanes/accompanist/issues/155) for more information.
  *

--- a/insets/src/main/java/dev/chrisbanes/accompanist/insets/Insets.kt
+++ b/insets/src/main/java/dev/chrisbanes/accompanist/insets/Insets.kt
@@ -106,18 +106,18 @@ val AmbientWindowInsets = staticAmbientOf<WindowInsets> {
 
 /**
  * This function sets up the necessary listeners on the given [view] to be able to observe
- * [WindowInsetsCompat].
+ * [WindowInsetsCompat] instance dispatched by the system.
  *
  * This function is useful for when you prefer to handle the ownership of the [WindowInsets]
  * yourself. One example of this is if you find yourself using [ProvideWindowInsets] in multiple
  * fragments.
  *
- * It is convenient to use [ProvideWindowInsets] in each fragment, but that result in a delay in
- * the insets being updated on startup, which visually results in a flicker.
+ * It is convenient to use [ProvideWindowInsets] in each fragment, but that can result in a
+ * delay in the initial inset update, which results in a visual flicker.
  * See [this issue](https://github.com/chrisbanes/accompanist/issues/155) for more information.
  *
  * The alternative is for fragments to manage the [WindowInsets] themselves, and call this function
- * once in `onCreateView()`:
+ * in `onCreateView()`:
  *
  * ```
  * override fun onCreateView(
@@ -184,7 +184,7 @@ fun WindowInsets.observeFromView(
  * Applies any [WindowInsetsCompat] values to [AmbientWindowInsets], which are then available
  * within [content].
  *
- * If you're using this within fragments, you may wish to take a look at
+ * If you're using this in fragments, you may wish to take a look at
  * [WindowInsets.observeFromView] for a more optimal solution.
  *
  * @param consumeWindowInsets Whether to consume any [WindowInsetsCompat]s which are dispatched to

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -62,5 +62,9 @@ dependencies {
     implementation Libs.AndroidX.Compose.foundation
     implementation Libs.AndroidX.Compose.layout
 
+    implementation Libs.AndroidX.coreKtx
+    implementation Libs.AndroidX.fragmentKtx
+    implementation Libs.AndroidX.lifecycleKtx
+
     implementation Libs.Kotlin.stdlib
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -132,6 +132,16 @@
         </activity>
 
         <activity
+            android:name=".insets.InsetsFragmentSample"
+            android:label="@string/insets_title_fragment"
+            android:theme="@style/Theme.AccompanistSample.NoActionBar.TransparentBars">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="dev.chrisbanes.accompanist.sample.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".insets.EdgeToEdgeLazyColumn"
             android:label="@string/insets_title_list"
             android:theme="@style/Theme.AccompanistSample.NoActionBar.TransparentBars">

--- a/sample/src/main/java/dev/chrisbanes/accompanist/sample/insets/InsetsFragmentSample.kt
+++ b/sample/src/main/java/dev/chrisbanes/accompanist/sample/insets/InsetsFragmentSample.kt
@@ -17,31 +17,40 @@
 package dev.chrisbanes.accompanist.sample.insets
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Face
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Providers
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.setContent
+import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
-import dev.chrisbanes.accompanist.insets.ProvideWindowInsets
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.commit
+import dev.chrisbanes.accompanist.insets.AmbientWindowInsets
+import dev.chrisbanes.accompanist.insets.WindowInsets
 import dev.chrisbanes.accompanist.insets.navigationBarsPadding
+import dev.chrisbanes.accompanist.insets.observeFromView
 import dev.chrisbanes.accompanist.insets.statusBarsPadding
 import dev.chrisbanes.accompanist.sample.R
 
-class InsetsBasicSample : ComponentActivity() {
+class InsetsFragmentSample : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -49,13 +58,32 @@ class InsetsBasicSample : ComponentActivity() {
         // insets
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
+        supportFragmentManager.commit {
+            replace(android.R.id.content, InsetsFragment())
+        }
+    }
+}
+
+class InsetsFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View = ComposeView(requireContext()).apply {
+        layoutParams = LayoutParams(MATCH_PARENT, MATCH_PARENT)
+
+        // We create a WindowInsets instance ourselves...
+        val windowInsets = WindowInsets()
+
+        // Since we're self-managing our own WindowInsets, we need to call observeFromView() to
+        // set the necessary listeners.
+        windowInsets.observeFromView(this)
+
         setContent {
-            MaterialTheme {
-                // We need to use ProvideWindowInsets to setup the necessary listeners which
-                // power the library
-                ProvideWindowInsets {
-                    Sample()
-                }
+            // Instead of calling ProvideWindowInsets, we use Providers to provide
+            // our self-managed WindowInsets instance to AmbientWindowInsets
+            Providers(AmbientWindowInsets provides windowInsets) {
+                Sample()
             }
         }
     }
@@ -66,7 +94,7 @@ private fun Sample() {
     Box(Modifier.fillMaxSize()) {
         TopAppBar(
             title = {
-                Text(stringResource(R.string.insets_title_basic))
+                Text(stringResource(R.string.insets_title_fragment))
             },
             modifier = Modifier
                 .align(Alignment.TopCenter)

--- a/sample/src/main/java/dev/chrisbanes/accompanist/sample/insets/InsetsFragmentSample.kt
+++ b/sample/src/main/java/dev/chrisbanes/accompanist/sample/insets/InsetsFragmentSample.kt
@@ -44,9 +44,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.commit
 import dev.chrisbanes.accompanist.insets.AmbientWindowInsets
-import dev.chrisbanes.accompanist.insets.WindowInsets
+import dev.chrisbanes.accompanist.insets.ViewWindowInsetObserver
 import dev.chrisbanes.accompanist.insets.navigationBarsPadding
-import dev.chrisbanes.accompanist.insets.observeFromView
 import dev.chrisbanes.accompanist.insets.statusBarsPadding
 import dev.chrisbanes.accompanist.sample.R
 
@@ -72,16 +71,15 @@ class InsetsFragment : Fragment() {
     ): View = ComposeView(requireContext()).apply {
         layoutParams = LayoutParams(MATCH_PARENT, MATCH_PARENT)
 
-        // We create a WindowInsets instance ourselves...
-        val windowInsets = WindowInsets()
-
-        // Since we're self-managing our own WindowInsets, we need to call observeFromView() to
-        // set the necessary listeners.
-        windowInsets.observeFromView(this)
+        // Create an ViewWindowInsetObserver using this view
+        val observer = ViewWindowInsetObserver(this)
+        // Call start() to start listening now.
+        // The WindowInsets instance is returned to us.
+        val windowInsets = observer.start()
 
         setContent {
             // Instead of calling ProvideWindowInsets, we use Providers to provide
-            // our self-managed WindowInsets instance to AmbientWindowInsets
+            // the WindowInsets instance from above to AmbientWindowInsets
             Providers(AmbientWindowInsets provides windowInsets) {
                 Sample()
             }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -30,5 +30,6 @@
     <string name="glide_title_lazy_row">Glide: Lazy row</string>
 
     <string name="insets_title_basic">Insets: Basic</string>
+    <string name="insets_title_fragment">Insets: Fragment</string>
     <string name="insets_title_list">Insets: Edge-to-edge list</string>
 </resources>


### PR DESCRIPTION
This enables fragments to manage their own `WindowInsets` and setup the necessary listeners earlier than `ProvideWindowInsets`. See the related issue for more information on why this is needed.

Fixes #155