### PR TITLE
[Image] Throw exception if incorrect data type is passed in

### DIFF
--- a/coil/src/androidTest/java/dev/chrisbanes/accompanist/coil/CoilTest.kt
+++ b/coil/src/androidTest/java/dev/chrisbanes/accompanist/coil/CoilTest.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.platform.AmbientContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.imageResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
@@ -528,6 +530,46 @@ class CoilTest {
             .assertIsDisplayed()
             .captureToImage()
             .assertPixels(Color.Red)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun data_drawable_throws() {
+        composeTestRule.setContent {
+            CoilImage(
+                data = android.graphics.drawable.ShapeDrawable(),
+                modifier = Modifier.preferredSize(128.dp, 128.dp),
+            )
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun data_imagebitmap_throws() {
+        composeTestRule.setContent {
+            CoilImage(
+                data = imageResource(android.R.drawable.ic_delete),
+                modifier = Modifier.preferredSize(128.dp, 128.dp),
+            )
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun data_imagevector_throws() {
+        composeTestRule.setContent {
+            CoilImage(
+                data = vectorResource(R.drawable.ic_android_black_24dp),
+                modifier = Modifier.preferredSize(128.dp, 128.dp),
+            )
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun data_painter_throws() {
+        composeTestRule.setContent {
+            CoilImage(
+                data = ColorPainter(Color.Magenta),
+                modifier = Modifier.preferredSize(128.dp, 128.dp),
+            )
+        }
     }
 }
 

--- a/coil/src/main/java/dev/chrisbanes/accompanist/coil/Coil.kt
+++ b/coil/src/main/java/dev/chrisbanes/accompanist/coil/Coil.kt
@@ -26,7 +26,9 @@ import androidx.compose.runtime.staticAmbientOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.AmbientContext
 import androidx.compose.ui.unit.IntSize
@@ -381,11 +383,38 @@ private fun coil.decode.DataSource.toDataSource(): DataSource = when (this) {
 
 @Composable
 internal fun Any.toImageRequest(): ImageRequest {
-    // If the developer is accidentally using the wrong function (data vs request), just
-    // pass the request through
-    return if (this is ImageRequest) this else {
-        // Otherwise we construct a GetRequest using the data parameter
-        val context = AmbientContext.current
-        remember(this) { ImageRequest.Builder(context).data(this).build() }
+    when (this) {
+        is android.graphics.drawable.Drawable -> {
+            throw IllegalArgumentException(
+                "Unsupported type: Drawable." +
+                    " If you wish to load a drawable, pass in the resource ID."
+            )
+        }
+        is ImageBitmap -> {
+            throw IllegalArgumentException(
+                "Unsupported type: ImageBitmap." +
+                    " If you wish to display this ImageBitmap, use androidx.compose.foundation.Image()"
+            )
+        }
+        is ImageVector -> {
+            throw IllegalArgumentException(
+                "Unsupported type: ImageVector." +
+                    " If you wish to display this ImageVector, use androidx.compose.foundation.Image()"
+            )
+        }
+        is Painter -> {
+            throw IllegalArgumentException(
+                "Unsupported type: Painter." +
+                    " If you wish to draw this Painter, use androidx.compose.foundation.Image()"
+            )
+        }
+        // If the developer is accidentally using the wrong function (data vs request), just
+        // pass the request through
+        is ImageRequest -> return this
+        else -> {
+            // Otherwise we construct a GetRequest using the data parameter
+            val context = AmbientContext.current
+            return remember(this) { ImageRequest.Builder(context).data(this).build() }
+        }
     }
 }

--- a/glide/src/androidTest/java/dev/chrisbanes/accompanist/glide/GlideTest.kt
+++ b/glide/src/androidTest/java/dev/chrisbanes/accompanist/glide/GlideTest.kt
@@ -17,6 +17,7 @@
 package dev.chrisbanes.accompanist.glide
 
 import android.graphics.drawable.Drawable
+import android.graphics.drawable.ShapeDrawable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.preferredSize
 import androidx.compose.material.Text
@@ -28,6 +29,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.platform.AmbientView
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.imageResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
@@ -500,5 +503,45 @@ class GlideTest {
             .assertIsDisplayed()
             .captureToImage()
             .assertPixels(Color.Red)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun data_drawable_throws() {
+        composeTestRule.setContent {
+            GlideImage(
+                data = ShapeDrawable(),
+                modifier = Modifier.preferredSize(128.dp, 128.dp),
+            )
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun data_imagebitmap_throws() {
+        composeTestRule.setContent {
+            GlideImage(
+                data = imageResource(android.R.drawable.ic_delete),
+                modifier = Modifier.preferredSize(128.dp, 128.dp),
+            )
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun data_imagevector_throws() {
+        composeTestRule.setContent {
+            GlideImage(
+                data = vectorResource(R.drawable.ic_android_black_24dp),
+                modifier = Modifier.preferredSize(128.dp, 128.dp),
+            )
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun data_painter_throws() {
+        composeTestRule.setContent {
+            GlideImage(
+                data = ColorPainter(Color.Magenta),
+                modifier = Modifier.preferredSize(128.dp, 128.dp),
+            )
+        }
     }
 }

--- a/glide/src/main/java/dev/chrisbanes/accompanist/glide/GlideImage.kt
+++ b/glide/src/main/java/dev/chrisbanes/accompanist/glide/GlideImage.kt
@@ -26,7 +26,9 @@ import androidx.compose.runtime.staticAmbientOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.AmbientView
 import androidx.compose.ui.unit.IntSize
@@ -101,7 +103,7 @@ fun GlideImage(
 ) {
     @OptIn(ExperimentalCoroutinesApi::class)
     ImageLoad(
-        request = requestManager.load(data),
+        request = requestManager.load(checkData(data)),
         requestKey = data, // Glide RequestBuilder doesn't support equality so we use the data
         executeRequest = { (r, size) -> requestManager.execute(r, size) },
         transformRequestForSize = { r, size ->
@@ -273,4 +275,34 @@ private fun com.bumptech.glide.load.DataSource.toDataSource(): DataSource = when
     com.bumptech.glide.load.DataSource.DATA_DISK_CACHE -> DataSource.DISK
     com.bumptech.glide.load.DataSource.RESOURCE_DISK_CACHE -> DataSource.DISK
     com.bumptech.glide.load.DataSource.MEMORY_CACHE -> DataSource.MEMORY
+}
+
+private fun checkData(data: Any): Any {
+    when (data) {
+        is Drawable -> {
+            throw IllegalArgumentException(
+                "Unsupported type: Drawable." +
+                    " If you wish to load a drawable, pass in the resource ID."
+            )
+        }
+        is ImageBitmap -> {
+            throw IllegalArgumentException(
+                "Unsupported type: ImageBitmap." +
+                    " If you wish to display this ImageBitmap, use androidx.compose.foundation.Image()"
+            )
+        }
+        is ImageVector -> {
+            throw IllegalArgumentException(
+                "Unsupported type: ImageVector." +
+                    " If you wish to display this ImageVector, use androidx.compose.foundation.Image()"
+            )
+        }
+        is Painter -> {
+            throw IllegalArgumentException(
+                "Unsupported type: Painter." +
+                    " If you wish to draw this Painter, use androidx.compose.foundation.Image()"
+            )
+        }
+    }
+    return data
 }

--- a/imageloading-testutils/src/main/res/drawable/ic_android_black_24dp.xml
+++ b/imageloading-testutils/src/main/res/drawable/ic_android_black_24dp.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright 2020 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24"
+        android:viewportHeight="24">
+    <path
+        android:pathData="M17.6,11.48 L19.44,8.3a0.63,0.63 0,0 0,-1.09 -0.63l-1.88,3.24a11.43,11.43 0,0 0,-8.94 0L5.65,7.67a0.63,0.63 0,0 0,-1.09 0.63L6.4,11.48A10.81,10.81 0,0 0,1 20L23,20A10.81,10.81 0,0 0,17.6 11.48ZM7,17.25A1.25,1.25 0,1 1,8.25 16,1.25 1.25,0 0,1 7,17.25ZM17,17.25A1.25,1.25 0,1 1,18.25 16,1.25 1.25,0 0,1 17,17.25Z"
+        android:fillColor="#FF000000"/>
+</vector>

--- a/picasso/src/androidTest/java/dev/chrisbanes/accompanist/picasso/PicassoTest.kt
+++ b/picasso/src/androidTest/java/dev/chrisbanes/accompanist/picasso/PicassoTest.kt
@@ -16,6 +16,7 @@
 
 package dev.chrisbanes.accompanist.picasso
 
+import android.graphics.drawable.ShapeDrawable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.preferredSize
 import androidx.compose.material.Text
@@ -25,6 +26,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.imageResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
@@ -469,5 +472,45 @@ class PicassoTest {
             .assertIsDisplayed()
             .captureToImage()
             .assertPixels(Color.Red)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun data_drawable_throws() {
+        composeTestRule.setContent {
+            PicassoImage(
+                data = ShapeDrawable(),
+                modifier = Modifier.preferredSize(128.dp, 128.dp),
+            )
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun data_imagebitmap_throws() {
+        composeTestRule.setContent {
+            PicassoImage(
+                data = imageResource(android.R.drawable.ic_delete),
+                modifier = Modifier.preferredSize(128.dp, 128.dp),
+            )
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun data_imagevector_throws() {
+        composeTestRule.setContent {
+            PicassoImage(
+                data = vectorResource(R.drawable.ic_android_black_24dp),
+                modifier = Modifier.preferredSize(128.dp, 128.dp),
+            )
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun data_painter_throws() {
+        composeTestRule.setContent {
+            PicassoImage(
+                data = ColorPainter(Color.Magenta),
+                modifier = Modifier.preferredSize(128.dp, 128.dp),
+            )
+        }
     }
 }

--- a/picasso/src/main/java/dev/chrisbanes/accompanist/picasso/Picasso.kt
+++ b/picasso/src/main/java/dev/chrisbanes/accompanist/picasso/Picasso.kt
@@ -28,9 +28,11 @@ import androidx.compose.runtime.staticAmbientOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.ImagePainter
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.IntSize
 import com.squareup.picasso.Picasso
@@ -257,5 +259,29 @@ private fun Any.toRequestCreator(picasso: Picasso): RequestCreator = when (this)
     is File -> picasso.load(this)
     is Int -> picasso.load(this)
     is HttpUrl -> picasso.load(Uri.parse(toString()))
+    is Drawable -> {
+        throw IllegalArgumentException(
+            "Unsupported type: Drawable." +
+                " If you wish to load a drawable, pass in the resource ID."
+        )
+    }
+    is ImageBitmap -> {
+        throw IllegalArgumentException(
+            "Unsupported type: ImageBitmap." +
+                " If you wish to display this ImageBitmap, use androidx.compose.foundation.Image()"
+        )
+    }
+    is ImageVector -> {
+        throw IllegalArgumentException(
+            "Unsupported type: ImageVector." +
+                " If you wish to display this ImageVector, use androidx.compose.foundation.Image()"
+        )
+    }
+    is Painter -> {
+        throw IllegalArgumentException(
+            "Unsupported type: Painter." +
+                " If you wish to draw this Painter, use androidx.compose.foundation.Image()"
+        )
+    }
     else -> throw IllegalArgumentException("Data is not of a type which Picasso supports: ${this::class.java}")
 }


### PR DESCRIPTION
GlideImage, CoilImage and PicassoImage currently all accept an `Any` param for data. There have been examples of developers passing in things like Drawables, ImageBitmaps, and others, which are not supported. To aid developers, we now throw an exception when any `Drawable`, `ImageBitmap`, `ImageVector` or `Painter` is passed in.