### PR TITLE
Update to Compose SNAPSHOT 7033025

### DIFF
--- a/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
@@ -58,7 +58,7 @@ object Libs {
         }
 
         object Compose {
-            const val snapshot = "7030654"
+            const val snapshot = "7033025"
             const val version = "1.0.0-SNAPSHOT"
 
             @JvmStatic

--- a/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/dev/chrisbanes/accompanist/buildsrc/dependencies.kt
@@ -28,7 +28,7 @@ object Libs {
     const val junit = "junit:junit:4.13"
 
     object Kotlin {
-        private const val version = "1.4.20"
+        private const val version = "1.4.21"
         const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib:$version"
         const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
 
@@ -58,7 +58,7 @@ object Libs {
         }
 
         object Compose {
-            const val snapshot = "7024175"
+            const val snapshot = "7030654"
             const val version = "1.0.0-SNAPSHOT"
 
             @JvmStatic

--- a/coil/src/main/java/dev/chrisbanes/accompanist/coil/Coil.kt
+++ b/coil/src/main/java/dev/chrisbanes/accompanist/coil/Coil.kt
@@ -148,8 +148,6 @@ fun CoilImage(
 ) {
     ImageLoad(
         request = request,
-        // Workaround. Need to work out this ImageRequest equality isn't working
-        requestKey = request.data,
         executeRequest = { imageLoader.execute(it).toResult() },
         transformRequestForSize = { r, size ->
             val sizedRequest = when {


### PR DESCRIPTION
Allows us to remove our workaround for `remember()`.

Required update to Kotlin 1.4.21.