### PR TITLE
Build docs before deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,12 +142,15 @@ jobs:
             ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
-      - name: Deploy to Sonatype
+      - name: Build docs
         # We manually run assemble & dokka before uploadArchives. If we only run uploadArchives,
         # the assemble and dokka tasks are run interleaved on each module, which can cause
         # connection timeouts to Sonatype (since we need to wait for assemble+dokka to finish).
-        # By front-loading the assemble+dokka tasks, the upload is much quicker.
-        run: ./gradlew assembleRelease dokkaHtml uploadArchives --no-parallel
+        # By front-loading the assemble+dokka tasks, the upload below is much quicker.
+        run: ./gradlew assembleRelease dokkaHtml
+
+      - name: Deploy to Sonatype
+        run: ./gradlew uploadArchives --no-parallel
         env:
           SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}


### PR DESCRIPTION
Our workaround isn't quite working now, so instead split out the commands to ensure that the build is ran before deploy.