### PR TITLE
Fix actions or navigationIcon covered by navigation bar in landscape

### DIFF
--- a/sample/src/main/java/dev/chrisbanes/accompanist/sample/insets/EdgeToEdgeLazyColumn.kt
+++ b/sample/src/main/java/dev/chrisbanes/accompanist/sample/insets/EdgeToEdgeLazyColumn.kt
@@ -163,7 +163,9 @@ fun InsetAwareTopAppBar(
             backgroundColor = Color.Transparent,
             contentColor = contentColor,
             elevation = 0.dp,
-            modifier = Modifier.statusBarsPadding()
+            modifier = Modifier
+                .statusBarsPadding()
+                .navigationBarsPadding(bottom = false)
         )
     }
 }


### PR DESCRIPTION
The sample for `InsetAwareTopAppBar` currently doesn't take into account the navigation bar in landscape mode. When in landscape, either the `navigationIcon` or an `action` are overlapped by the Navigation bar. This PR fixes this so that all icons are visible in portrait as well as landscape mode.

Ideally, I think this might be better off applied in something like an `InsetAwareScaffold` since the `bodyContent` will also need to have this modifier.