### PR TITLE
Fixed ColorMatrix brightness adjustment

### DIFF
--- a/imageloading-core/src/main/java/dev/chrisbanes/accompanist/imageloading/MaterialLoadingImage.kt
+++ b/imageloading-core/src/main/java/dev/chrisbanes/accompanist/imageloading/MaterialLoadingImage.kt
@@ -259,9 +259,9 @@ private fun ColorMatrix.setSaturation(saturation: Float) {
 
 private fun ColorMatrix.setBrightness(brightness: Float) {
     val darkening = (1f - brightness) * 255
-    this[0, 3] = darkening
-    this[1, 3] = darkening
-    this[2, 3] = darkening
+    this[0, 4] = darkening
+    this[1, 4] = darkening
+    this[2, 4] = darkening
 }
 
 private fun ColorMatrix.setAlpha(alpha: Float) = set(row = 3, column = 3, v = alpha)


### PR DESCRIPTION
I'm not a ColorMatrix expert but it seems to me the correct way to set brightness is to use 5th columns of color matrix - not 4th.

Here's another implementation of Material image loading that uses the proposed way of setting brightness http://blog.neteril.org/blog/2014/11/23/android-material-image-loading/

Feel free to close this if I'm wrong.