### PR TITLE
Handle CancellationException in produceState

### DIFF
--- a/imageloading-core/src/main/java/dev/chrisbanes/accompanist/imageloading/ImageLoad.kt
+++ b/imageloading-core/src/main/java/dev/chrisbanes/accompanist/imageloading/ImageLoad.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.IntSize
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * A generic image loading composable, which provides hooks for image loading libraries to use.
@@ -79,6 +80,10 @@ fun <R : Any, TR : Any> ImageLoad(
             ?.let { transformedRequest ->
                 try {
                     updatedExecuteRequest(transformedRequest)
+                } catch (ce: CancellationException) {
+                    // We specifically don't do anything for the request coroutine being
+                    // cancelled: https://github.com/chrisbanes/accompanist/issues/217
+                    throw ce
                 } catch (throwable: Throwable) {
                     ImageLoadState.Error(painter = null, throwable = throwable)
                 }.also(updatedOnRequestCompleted)


### PR DESCRIPTION
Currently our logic will treat a `CancellationException` as an error result, rather than the request being
cancelled. This PR updates our logic to re-throw `CancellationException`s.

Fixes #217 