### PR TITLE
[AppCompat] Set LocalContentColor

### DIFF
--- a/appcompat-theme/src/androidTest/java/dev/chrisbanes/accompanist/appcompattheme/AppCompatThemeTest.kt
+++ b/appcompat-theme/src/androidTest/java/dev/chrisbanes/accompanist/appcompattheme/AppCompatThemeTest.kt
@@ -20,6 +20,7 @@ import android.view.ContextThemeWrapper
 import androidx.annotation.StyleRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Typography
 import androidx.compose.runtime.Composable
@@ -83,6 +84,8 @@ class AppCompatThemeTest<T : AppCompatActivity>(activityClass: Class<T>) {
             // By default, onBackground is calculated to the highest contrast of black/white
             // against background
             assertEquals(Color.Black, color.onBackground)
+            // AppCompatTheme updates the LocalContentColor to match the calculated onBackground
+            assertEquals(Color.Black, LocalContentColor.current)
         }
     }
 
@@ -105,6 +108,8 @@ class AppCompatThemeTest<T : AppCompatActivity>(activityClass: Class<T>) {
                 // Our textColorPrimary (midnight_blue) contains provides enough contrast vs
                 // the background color, so it should be used.
                 assertEquals(colorResource(R.color.midnight_blue), color.onBackground)
+                // AppCompatTheme updates the LocalContentColor to match the calculated onBackground
+                assertEquals(colorResource(R.color.midnight_blue), LocalContentColor.current)
 
                 if (!isSystemInDarkTheme()) {
                     // Our textColorPrimary (midnight_blue) provides enough contrast vs

--- a/appcompat-theme/src/main/java/dev/chrisbanes/accompanist/appcompattheme/AppCompatTheme.kt
+++ b/appcompat-theme/src/main/java/dev/chrisbanes/accompanist/appcompattheme/AppCompatTheme.kt
@@ -15,16 +15,19 @@
  */
 
 @file:JvmName("AppCompatTheme")
+
 package dev.chrisbanes.accompanist.appcompattheme
 
 import android.content.Context
 import androidx.compose.material.Colors
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Shapes
 import androidx.compose.material.Typography
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -112,8 +115,14 @@ fun AppCompatTheme(
         colors = themeParams.colors ?: MaterialTheme.colors,
         typography = themeParams.typography ?: MaterialTheme.typography,
         shapes = shapes,
-        content = content
-    )
+    ) {
+        // We update the LocalContentColor to match our onBackground. This allows the default
+        // content color to be more appropriate to the theme background
+        CompositionLocalProvider(
+            LocalContentColor provides MaterialTheme.colors.onBackground,
+            content = content
+        )
+    }
 }
 
 /**
@@ -155,7 +164,8 @@ fun Context.createAppCompatTheme(
         /* First we'll read the Material color palette */
         val primary = ta.getComposeColor(R.styleable.AppCompatThemeAdapterTheme_colorPrimary)
         // colorPrimaryDark is roughly equivalent to primaryVariant
-        val primaryVariant = ta.getComposeColor(R.styleable.AppCompatThemeAdapterTheme_colorPrimaryDark)
+        val primaryVariant =
+            ta.getComposeColor(R.styleable.AppCompatThemeAdapterTheme_colorPrimaryDark)
         val onPrimary = primary.calculateOnColor()
 
         // colorAccent is roughly equivalent to secondary
@@ -176,7 +186,8 @@ fun Context.createAppCompatTheme(
         val surface = defaultColors.surface
         val onSurface = surface.calculateOnColorWithTextColorPrimary(textColorPrimary)
 
-        val background = ta.getComposeColor(R.styleable.AppCompatThemeAdapterTheme_android_colorBackground)
+        val background =
+            ta.getComposeColor(R.styleable.AppCompatThemeAdapterTheme_android_colorBackground)
         val onBackground = background.calculateOnColorWithTextColorPrimary(textColorPrimary)
 
         val error = ta.getComposeColor(R.styleable.AppCompatThemeAdapterTheme_colorError)


### PR DESCRIPTION
We update the `LocalContentColor` to match our `onBackground`. This allows the default content color to be more appropriate to the theme background.

Fixes #222 